### PR TITLE
Previous searches

### DIFF
--- a/resources/site-packages/kodi/__init__.py
+++ b/resources/site-packages/kodi/__init__.py
@@ -6,6 +6,9 @@
 # Distributed under terms of the MIT license.
 #
 import sys
+import os.path
+
+PREV_SOURCES_FILENAME = 'prev_sources.list'
 
 try:  # real kodi
     import xbmc
@@ -67,9 +70,18 @@ class Plugin:
                 self._args[k] = v[0]
             else:
                 self._args[k] = v
+
         # previously searched text (with almost one success result)
-        # TODO: add persistent storing
-        previous_searches_list = []
+        prev_searches_path = os.path.join(self._addon.getAddonInfo('path'), PREV_SOURCES_FILENAME)
+        if not os.path.exists(prev_searches_path):
+            self._previous_searches_list = []
+        else:
+            with open(prev_searches_path, 'r') as fo:
+                self._previous_searches_list = fo.readlines()
+        self._previous_searches_fo = open(prev_searches_path, 'a+')
+
+    def __del__(self):
+        self._previous_searches_fo.close()
 
     @property
     def icon(self):
@@ -93,6 +105,7 @@ class Plugin:
         thumb = kwargs.get('thumb')
         li = list_item(name, thumb)
         li.setProperty('IsPlayable', 'true')
+        li.setInfo('video', dict())
         ret = xbmcplugin.addDirectoryItem(self._handler, url, li, False)
         if not ret:
             logger.error('failed to add {0} playable item'.format(name))
@@ -126,3 +139,11 @@ class Plugin:
             message.encode('ascii', 'ignore'),
             timeout,
             self.icon))
+
+    def add_prev_search(self, term):
+        if term not in self._previous_searches_list:
+            self._previous_searches_list.append(term)
+            self._previous_searches_fo.write(term + os.linesep)
+
+    def previous_searches_list(self):
+        return self._previous_searches_list

--- a/resources/site-packages/kodi/__init__.py
+++ b/resources/site-packages/kodi/__init__.py
@@ -67,6 +67,9 @@ class Plugin:
                 self._args[k] = v[0]
             else:
                 self._args[k] = v
+        # previously searched text (with almost one success result)
+        # TODO: add persistent storing
+        previous_searches_list = []
 
     @property
     def icon(self):

--- a/resources/site-packages/plugin_video/screen.py
+++ b/resources/site-packages/plugin_video/screen.py
@@ -14,14 +14,20 @@ def week(plugin):
     date = datetime.today()
     for date_offset in range(7):
         datestr = date.strftime('%d.%m.%Y')
+        dirname = date.strftime('%A (%d %b)')
         dayurl = plugin.make_url({
             'screen': 'day',
             'date': datestr,
         })
-        plugin.add_screen_directory(datestr, dayurl)
+        plugin.add_screen_directory(dirname, dayurl)
         date -= timedelta(days=1)
+
     searchurl = plugin.make_url({'screen': 'search'})
-    plugin.add_screen_directory('[COLOR FFFFD700]поиск[/COLOR]', searchurl)
+    plugin.add_screen_directory('[COLOR FFFFD700]Поиск[/COLOR]', searchurl)
+
+    searchurl = plugin.make_url({'screen': 'previous_search'})
+    plugin.add_screen_directory('[COLOR FFFFD700]Предыдущиe поиски[/COLOR]', searchurl)
+
     plugin.publish_screen(True)
 
 
@@ -51,6 +57,7 @@ def direct_search(plugin):
             'screen "direct_search"', plugin.args))
         plugin.publish_screen(False)
         return
+    something_found = True;
     for i in seasonvar.search(term):
         if i['url'] is not None:
             season_url = i['url'].encode('utf-8')
@@ -63,6 +70,10 @@ def direct_search(plugin):
                     url,
                     thumb=seasonvar.thumb_url(season_url)
             )
+    else:
+        something_found = False
+    if something_found:
+        plugin.previous_searches_list.append(term)
     plugin.publish_screen(True)
 
 
@@ -70,6 +81,18 @@ def search(plugin):
     term = plugin.read_input('Что искать?')
     plugin.args["q"] = term
     direct_search(plugin)
+
+
+def previous_searches(plugin):
+    for what_to_search in plugin.previous_searches_list:
+        url = plugin.make_url({
+            'screen': 'direct_search',
+            'q': what_to_search,
+        })
+        name = '[COLOR FFFFD700]{0}[/COLOR]'.format(what_to_search)
+        plugin.add_screen_directory(name, url)
+
+    plugin.publish_screen(True)
 
 
 def episodes(plugin):

--- a/resources/site-packages/plugin_video/screen.py
+++ b/resources/site-packages/plugin_video/screen.py
@@ -14,18 +14,18 @@ def week(plugin):
     date = datetime.today()
     for date_offset in range(7):
         datestr = date.strftime('%d.%m.%Y')
-        dirname = date.strftime('%A (%d %b)')
+        human_readable_date = date.strftime('%A ( %d %B %Y )')
         dayurl = plugin.make_url({
             'screen': 'day',
             'date': datestr,
         })
-        plugin.add_screen_directory(dirname, dayurl)
+        plugin.add_screen_directory(human_readable_date, dayurl)
         date -= timedelta(days=1)
 
     searchurl = plugin.make_url({'screen': 'search'})
     plugin.add_screen_directory('[COLOR FFFFD700]Поиск[/COLOR]', searchurl)
 
-    searchurl = plugin.make_url({'screen': 'previous_search'})
+    searchurl = plugin.make_url({'screen': 'previous_searches'})
     plugin.add_screen_directory('[COLOR FFFFD700]Предыдущиe поиски[/COLOR]', searchurl)
 
     plugin.publish_screen(True)
@@ -57,9 +57,11 @@ def direct_search(plugin):
             'screen "direct_search"', plugin.args))
         plugin.publish_screen(False)
         return
-    something_found = True;
+    something_found = False
     for i in seasonvar.search(term):
         if i['url'] is not None:
+            something_found = True
+
             season_url = i['url'].encode('utf-8')
             url = plugin.make_url({
                 'screen': 'episodes',
@@ -70,10 +72,10 @@ def direct_search(plugin):
                     url,
                     thumb=seasonvar.thumb_url(season_url)
             )
-    else:
-        something_found = False
+
     if something_found:
-        plugin.previous_searches_list.append(term)
+        plugin.add_prev_search(term)
+
     plugin.publish_screen(True)
 
 
@@ -84,7 +86,7 @@ def search(plugin):
 
 
 def previous_searches(plugin):
-    for what_to_search in plugin.previous_searches_list:
+    for what_to_search in plugin.previous_searches_list():
         url = plugin.make_url({
             'screen': 'direct_search',
             'q': what_to_search,
@@ -220,6 +222,7 @@ def render(plugin):
          'seasons': seasons,
          'translations': translations,
          'search': search,
+         'previous_searches': previous_searches,
          }[screen](plugin)
     except KeyError:
         logger.error('unexpected screen "{0}"'.format(screen))

--- a/resources/site-packages/seasonvar/parser.py
+++ b/resources/site-packages/seasonvar/parser.py
@@ -6,6 +6,7 @@
 # Distributed under terms of the MIT license.
 #
 import re
+import base64
 
 
 def main_page_items(main_page_html, datestr):
@@ -94,10 +95,14 @@ def episodes(playlist):
     for entry in playlist:
         if 'playlist' in entry:
             for episode in entry['playlist']:
-                yield {'url': episode['file'],
+                fl = re.sub(r"\/\/.*?=", '', episode['file'])
+                fl = base64.b64decode(fl[2:])
+                yield {'url': fl,
                        'name': episode['title'].replace('<br>', ' ')}
         else:
-            yield {'url': entry['file'],
+            fl = re.sub(r"\/\/.*?=", '', entry['file'])
+            fl = base64.b64decode(fl[2:])
+            yield {'url': fl,
                    'name': entry['title'].replace('<br>', ' ')}
 
 

--- a/resources/site-packages/seasonvar/parser.py
+++ b/resources/site-packages/seasonvar/parser.py
@@ -95,12 +95,12 @@ def episodes(playlist):
     for entry in playlist:
         if 'playlist' in entry:
             for episode in entry['playlist']:
-                fl = re.sub(r"\/\/.*?=", '', episode['file'])
+                fl = re.sub(r"//.*?=", '', episode['file'])
                 fl = base64.b64decode(fl[2:])
                 yield {'url': fl,
                        'name': episode['title'].replace('<br>', ' ')}
         else:
-            fl = re.sub(r"\/\/.*?=", '', entry['file'])
+            fl = re.sub(r"//.*?=", '', entry['file'])
             fl = base64.b64decode(fl[2:])
             yield {'url': fl,
                    'name': entry['title'].replace('<br>', ' ')}
@@ -122,8 +122,7 @@ def _season_and_serial(season_page_html):
 def _secure_and_time(season_page_html):
     r = re.compile(r"var\s+data4play\s*=\s*{\s*"
                    r"'secureMark'\s*:\s*'([a-f0-9]+)',\s*"
-                   r"'time'\s*:\s*([0-9]+)\s*"
-                   r"}")
+                   r"'time'\s*:\s*([0-9]+)\s*")
     match = r.search(season_page_html)
     if match:
         return match.groups()


### PR DESCRIPTION
 Add item "Previous Searches" on main screen

Plugin store phrases which user successfully tried to search
    
Searches will be stored in file 'prev_sources.list' located in plugin folder
        File format - plain text.
        Each line of that file will contain text of one search.
    
Change format of day folders titles: '%d.%m.%Y' -> '%A ( %d %B %Y )'
    Example of title:
        Wednesday ( 27 November 2019 )
    
Fix add video directory item: for Kodi Leia also need to call 'setInfo' method
